### PR TITLE
plugin settings for default code language

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -11,6 +11,8 @@ GET RID OF WRITING:
             MyClass.new(:blah)
         </code>
     <pre>
+    
+This plugin also has a _Settings_ page where you can configure the desired default language for the dropdown menu.
 
 It's a requested feature on redmine.org and I decided to try to implement it for my needs. Thankfully Felix S. has provided his code. I used the "redmine_wiki_extensions" which guides me through the process.
 

--- a/app/views/settings/_redmine_codebutton_settings.html.erb
+++ b/app/views/settings/_redmine_codebutton_settings.html.erb
@@ -1,0 +1,4 @@
+<p>
+  <label><%= l(:settings_default_label) %>:</label>
+  <%= select_tag "settings[default_language]", options_for_select(["c", "clojure", "cpp", "css", "delphi", "diff", "erb", "groovy", "haml", "html", "java", "javascript", "json", "php", "python", "ruby", "sql", "text", "xml", "yaml"], @settings['default_language']), include_blank: true %>
+</p>

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -10,7 +10,7 @@ jsToolBar.prototype.elements.codehighlight = {
             var languageOptions = [];
 	    var select = "";
             for (var i = 0; i < codeRayLanguages.length; i++) {
-		if ( codeRayLanguages[i].indexOf("sql") > -1 )
+		if ( codeRayLanguages[i].indexOf("xml") > -1 )
 			select = "selected" ;
 		else 
 		        select = "";

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -8,13 +8,13 @@ jsToolBar.prototype.elements.codehighlight = {
             var codeRayLanguages = ["c", "clojure", "cpp", "css", "delphi", "diff", "erb", "groovy", "haml", "html", "java", "javascript", "json", "php", "python", "ruby", "sql", "text", "xml", "yaml"];
 
             var languageOptions = [];
-	    var select = "";
+	         var select = "";
             for (var i = 0; i < codeRayLanguages.length; i++) {
-		if ( codeRayLanguages[i].indexOf("xml") > -1 )
-			select = "selected" ;
-		else 
+              if ( codeRayLanguages[i].indexOf(jsToolBar.prototype.codehighlightDefaultLanguage) > -1 )
+                 select = "selected" ;
+              else
 		        select = "";
-		languageOptions[i] = "<option " + select + ">" + codeRayLanguages[i] + "</option>";
+		        languageOptions[i] = "<option " + select + ">" + codeRayLanguages[i] + "</option>";
             }
             var languageSelect = "<select>" + languageOptions.join("") + "</select>";
             var hideJs = "hideModal(this);$('#toolbar-code-options').remove();return false;";

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -8,8 +8,13 @@ jsToolBar.prototype.elements.codehighlight = {
             var codeRayLanguages = ["c", "clojure", "cpp", "css", "delphi", "diff", "erb", "groovy", "haml", "html", "java", "javascript", "json", "php", "python", "ruby", "sql", "text", "xml", "yaml"];
 
             var languageOptions = [];
+	    var select = "";
             for (var i = 0; i < codeRayLanguages.length; i++) {
-                languageOptions[i] = "<option>" + codeRayLanguages[i] + "</option>";
+		if ( codeRayLanguages[i].indexOf("sql") > -1 )
+			select = "selected" ;
+		else 
+		        select = "";
+		languageOptions[i] = "<option " + select + ">" + codeRayLanguages[i] + "</option>";
             }
             var languageSelect = "<select>" + languageOptions.join("") + "</select>";
             var hideJs = "hideModal(this);$('#toolbar-code-options').remove();return false;";

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,3 @@
 # German strings go here for Rails i18n
-en:
+de:
   settings_default_label: "Standard-Sprache"

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,0 +1,3 @@
+# German strings go here for Rails i18n
+en:
+  settings_default_label: "Standard-Sprache"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,3 @@
 # English strings go here for Rails i18n
 en:
-  # my_label: "My label"
+  settings_default_label: "Default code language"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,2 +1,0 @@
-# Plugin's routes
-# See: http://guides.rubyonrails.org/routing.html

--- a/init.rb
+++ b/init.rb
@@ -2,9 +2,13 @@ Redmine::Plugin.register :redmine_codebutton do
   name 'Code Highlight plugin'
   author 'Jan Jezek'
   description 'This is a plugin for Redmine. It adds a CodeHighlight Button to the editor, which wraps a code around selected text'
-  version '0.0.1'
+  version '0.1.0'
   url 'https://github.com/mediatainment/redmine-codebutton'
   author_url 'http://www.mediatainment-productions.com'
+  
+  settings :default => {
+    'default_language' => false
+  }, :partial => 'redmine_codebutton_settings'
 end
 
 Rails.configuration.to_prepare do

--- a/lib/wiki_codehighlight_helper_patch.rb
+++ b/lib/wiki_codehighlight_helper_patch.rb
@@ -38,8 +38,10 @@ module HelperMethodsWikiExtensions
       content_for :header_tags do
         o = javascript_include_tag('wiki-codehighlight.js', :plugin => 'redmine_codebutton')
         o << stylesheet_link_tag('wiki-codehighlight.css', :plugin => 'redmine_codebutton')
-        o << javascript_tag("jsToolBar.prototype.codehighlightDefaultLanguage = '" + Setting.plugin_redmine_codebutton['default_language'] + "';")
-        o.html_safe
+		if Setting.plugin_redmine_codebutton['default_language']
+          o << javascript_tag("jsToolBar.prototype.codehighlightDefaultLanguage = '" + Setting.plugin_redmine_codebutton['default_language'] + "';")
+        end
+		o.html_safe
       end
       @heads_for_wiki_redmine_codebutton_included = true
     end

--- a/lib/wiki_codehighlight_helper_patch.rb
+++ b/lib/wiki_codehighlight_helper_patch.rb
@@ -38,6 +38,7 @@ module HelperMethodsWikiExtensions
       content_for :header_tags do
         o = javascript_include_tag('wiki-codehighlight.js', :plugin => 'redmine_codebutton')
         o << stylesheet_link_tag('wiki-codehighlight.css', :plugin => 'redmine_codebutton')
+        o << javascript_tag("jsToolBar.prototype.codehighlightDefaultLanguage = '" + Setting.plugin_redmine_codebutton['default_language'] + "';")
         o.html_safe
       end
       @heads_for_wiki_redmine_codebutton_included = true


### PR DESCRIPTION
This branch adds a codebutton settings page in _Administration_ > _Plugins_ to configure the default language in the dropdown menu.

This is inspired by @mindo's changes... :)

Feel free to merge the changes! I also bumped the version number to 0.1.0

---

And by the way: You probably have to rename the plugin in the redmine.org repo because you now have two different plugin identifier!

Your plugin is registered as "redmine_codebutton" in each redmine instance ( ``Redmine::Plugin.register :redmine_codebutton do` ) but the redmine plugin update check (introduced in 2.5.0) can't find the plugin in the redmine repo because there it is named "codehightlight_button" (with a typo, btw :smirk: ).