### PR TITLE
version 0.2.0: replace native Redmine 3.3 code highlight button with our button

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+Gemfile.lock
+.DS_Store
+.bundle

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -1,4 +1,4 @@
-jsToolBar.prototype.elements.codehighlight = {
+codehighlight = {
     type: 'button',
     title: 'Highlighted code',
     fn: {
@@ -8,7 +8,7 @@ jsToolBar.prototype.elements.codehighlight = {
             var codeRayLanguages = ["bash", "c", "clojure", "cpp", "css", "delphi", "diff", "erb", "groovy", "haml", "html", "java", "javascript", "json", "php", "python", "ruby", "sql", "text", "xml", "yaml"];
 
             var languageOptions = [];
-	         var select = "";
+	          var select = "";
             for (var i = 0; i < codeRayLanguages.length; i++) {
               if ( codeRayLanguages[i].indexOf(jsToolBar.prototype.codehighlightDefaultLanguage) > -1 )
                  select = "selected" ;
@@ -25,4 +25,12 @@ jsToolBar.prototype.elements.codehighlight = {
             $('#toolbar-code-options select').focus();
         }
     }
+}
+
+/* Redmine >= 3.3: replace native code highlight button with our button */
+if(jsToolBar.prototype.elements.precode !== undefined) {
+  jsToolBar.prototype.elements.precode = codehighlight;
+} else {
+  /* Redmine <= 3.2: Add our button at the the pf the list */
+  jsToolBar.prototype.elements.codehighlight = codehighlight;
 }

--- a/init.rb
+++ b/init.rb
@@ -2,10 +2,10 @@ Redmine::Plugin.register :redmine_codebutton do
   name 'Code Highlight plugin'
   author 'Jan Jezek'
   description 'This is a plugin for Redmine. It adds a CodeHighlight Button to the editor, which wraps a code around selected text'
-  version '0.1.0'
+  version '0.2.0'
   url 'https://github.com/mediatainment/redmine-codebutton'
   author_url 'http://www.mediatainment-productions.com'
-  
+
   settings :default => {
     'default_language' => false
   }, :partial => 'redmine_codebutton_settings'


### PR DESCRIPTION
This replaces the native code highlight dropdown (Redmine >= 3.3) with our advanced button.

Also raises the version number to 0.2.0