### PR TITLE
Add support for Markdown codeblocks

### DIFF
--- a/app/views/settings/_redmine_codebutton_settings.html.erb
+++ b/app/views/settings/_redmine_codebutton_settings.html.erb
@@ -2,3 +2,9 @@
   <label><%= l(:settings_default_label) %>:</label>
   <%= select_tag "settings[default_language]", options_for_select(["bash", "c", "clojure", "cpp", "css", "delphi", "diff", "erb", "groovy", "haml", "html", "java", "javascript", "json", "php", "python", "ruby", "sql", "text", "xml", "yaml"], @settings['default_language']), include_blank: true %>
 </p>
+<%if Setting.text_formatting == "markdown"%>
+  <p>
+    <label><%= l(:settings_markdown_syntax) %>:</label>
+    <%= select_tag "settings[markdown_syntax]", options_for_select({ "~~~ (Redmine)" => "~~~", "``` (GitHub)" => "```"}, @settings['markdown_syntax']), include_blank: false %>
+  </p>
+<%end%>

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -17,8 +17,23 @@ codehighlight = {
 		        languageOptions[i] = "<option " + select + ">" + codeRayLanguages[i] + "</option>";
             }
             var languageSelect = "<select>" + languageOptions.join("") + "</select>";
+
+            var selectVal = "\' + $(this).closest(\'div\').find(\'select\').first().val() + \'";
+            var encloseContent = "";
+            if(String(jsToolBar.prototype.elements.strong.fn.wiki).match(/\*/g).length == 1) {
+              /* Wiki formatter: Textile */
+              encloseContent = "\'<pre><code class=&quot;"+selectVal+"&quot;>\\n\', \'\\n</code></pre>\'";
+            } else {
+              /* Wiki formatter: Markdown */
+              encloseContent = "\'~~~ "+selectVal+"\\n\', \'\\n~~~\'";
+            }
+
             var hideJs = "hideModal(this);$('#toolbar-code-options').remove();return false;";
-            var questionBox = '<div id="toolbar-code-options" style="display: none"><form action="#"><h3 class="title">Highlight code for</h3><p><label>Language ' + languageSelect + '</label></p><p class="buttons"><input onclick="precodeTextField.encloseLineSelection(\'<pre><code class=&quot;\' + $(this).closest(\'div\').find(\'select\').first().val() + \'&quot;>\\n\', \'\\n</code></pre>\');'+hideJs+'" type="submit" value="Insert code"><input onclick="'+hideJs+'" type="button" value="Cancel"></p></form></div>';
+            var questionBox = '<div id="toolbar-code-options" style="display: none">\
+              <form action="#"><h3 class="title">Highlight code for</h3>\
+              <p><label>Language ' + languageSelect + '</label></p><p class="buttons">\
+              <input onclick="precodeTextField.encloseLineSelection('+encloseContent+');'+hideJs+'" type="submit" value="Insert code">\
+              <input onclick="'+hideJs+'" type="button" value="Cancel"></p></form></div>';
 
             $('#main').append(questionBox);
             showModal('toolbar-code-options', '200px');

--- a/assets/javascripts/wiki-codehighlight.js
+++ b/assets/javascripts/wiki-codehighlight.js
@@ -25,7 +25,8 @@ codehighlight = {
               encloseContent = "\'<pre><code class=&quot;"+selectVal+"&quot;>\\n\', \'\\n</code></pre>\'";
             } else {
               /* Wiki formatter: Markdown */
-              encloseContent = "\'~~~ "+selectVal+"\\n\', \'\\n~~~\'";
+              var syntax = jsToolBar.prototype.codehighlightMarkdownSyntax;
+              encloseContent = "\'"+syntax+" "+selectVal+"\\n\', \'\\n"+syntax+"\'";
             }
 
             var hideJs = "hideModal(this);$('#toolbar-code-options').remove();return false;";

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -1,3 +1,4 @@
 # German strings go here for Rails i18n
 de:
   settings_default_label: "Standard-Sprache"
+  settings_markdown_syntax: "Markdown Code-Block-Syntax"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,3 +1,4 @@
 # English strings go here for Rails i18n
 en:
   settings_default_label: "Default code language"
+  settings_markdown_syntax: "Markdown code block syntax"

--- a/init.rb
+++ b/init.rb
@@ -15,8 +15,18 @@ Rails.configuration.to_prepare do
   # Guards against including the module multiple time (like in tests)
   # and registering multiple callbacks
 
-  unless Redmine::WikiFormatting::Textile::Helper.included_modules.include? WikiCodehighlightHelperPatch
-    Redmine::WikiFormatting::Textile::Helper.send(:include, WikiCodehighlightHelperPatch)
+  # send Patches to all wiki formatters available to be able to switch formatter without app restart
+  Redmine::WikiFormatting::format_names.each do |format|
+    case format
+    when "markdown"
+      unless Redmine::WikiFormatting::Markdown::Helper.included_modules.include? WikiCodehighlightHelperPatch
+        Redmine::WikiFormatting::Markdown::Helper.send(:include, WikiCodehighlightHelperPatch)
+      end
+    when "textile"
+      unless Redmine::WikiFormatting::Textile::Helper.included_modules.include? WikiCodehighlightHelperPatch
+        Redmine::WikiFormatting::Textile::Helper.send(:include, WikiCodehighlightHelperPatch)
+      end
+    end
   end
 
 end

--- a/init.rb
+++ b/init.rb
@@ -7,7 +7,8 @@ Redmine::Plugin.register :redmine_codebutton do
   author_url 'http://www.mediatainment-productions.com'
 
   settings :default => {
-    'default_language' => false
+    'default_language' => false,
+    'markdown_syntax' => '~~~'
   }, :partial => 'redmine_codebutton_settings'
 end
 

--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ Redmine::Plugin.register :redmine_codebutton do
   name 'Code Highlight plugin'
   author 'Jan Jezek'
   description 'This is a plugin for Redmine. It adds a CodeHighlight Button to the editor, which wraps a code around selected text'
-  version '0.2.0'
+  version '0.3.0'
   url 'https://github.com/mediatainment/redmine-codebutton'
   author_url 'http://www.mediatainment-productions.com'
 

--- a/lib/wiki_codehighlight_helper_patch.rb
+++ b/lib/wiki_codehighlight_helper_patch.rb
@@ -22,7 +22,7 @@ module WikiCodehighlightHelperPatch
     base.send(:include, HelperMethodsWikiExtensions)
 
     base.class_eval do
-      unloadable # Send unloadable so it will not be unloaded in development    
+      unloadable # Send unloadable so it will not be unloaded in development
       alias_method_chain :heads_for_wiki_formatter, :redmine_codebutton
     end
   end
@@ -38,10 +38,23 @@ module HelperMethodsWikiExtensions
       content_for :header_tags do
         o = javascript_include_tag('wiki-codehighlight.js', :plugin => 'redmine_codebutton')
         o << stylesheet_link_tag('wiki-codehighlight.css', :plugin => 'redmine_codebutton')
-		if Setting.plugin_redmine_codebutton['default_language']
-          o << javascript_tag("jsToolBar.prototype.codehighlightDefaultLanguage = '" + Setting.plugin_redmine_codebutton['default_language'] + "';")
+
+        settings = ""
+        if Setting.plugin_redmine_codebutton['default_language']
+          settings << "jsToolBar.prototype.codehighlightDefaultLanguage = '" + Setting.plugin_redmine_codebutton['default_language'] + "';"
         end
-		o.html_safe
+        if Setting.text_formatting == "markdown"
+          markdown_syntax = Setting.plugin_redmine_codebutton['markdown_syntax'].to_s
+          if markdown_syntax.empty?
+            markdown_syntax = '~~~'
+          end
+          settings << "jsToolBar.prototype.codehighlightMarkdownSyntax = '" + markdown_syntax + "';"
+        end
+        unless settings.empty?
+          o << javascript_tag(settings)
+        end
+
+        o.html_safe
       end
       @heads_for_wiki_redmine_codebutton_included = true
     end
@@ -54,5 +67,3 @@ module HelperMethodsWikiExtensions
 
 
 end
-
-


### PR DESCRIPTION
Beginning with Redmine 3.2 (I guess) Redmine supports Markdown syntax as an alternative to Textile.

These changes add Markdown support to the plugin which inserts standard Redmine markdown codeblocks:

```
~~~ css
p.class { color: red; }
~~~
```

![bildschirmfoto 2017-08-05 um 17 26 41](https://user-images.githubusercontent.com/365118/28996654-1167ca7c-7a05-11e7-92fe-395d6db8f6fd.png)

The user can also choose between different supported markdown syntax styles in the plugin settings:

![bildschirmfoto 2017-08-05 um 17 32 13](https://user-images.githubusercontent.com/365118/28996664-27d181cc-7a05-11e7-9314-d1b4fcadfe44.png)

Redmine style is default.

This also bumps plugin version to 0.3.0